### PR TITLE
Revert delivery date changes

### DIFF
--- a/app.py
+++ b/app.py
@@ -46,7 +46,6 @@ class Order(Base):
     product_quantity = Column('Product Quantity', Integer)
     order_date = Column('Order Date', DateTime)
     shipping_date = Column('Shipping Date', DateTime)
-    delivery_date = Column('Delivery Date', DateTime)
 
 # define routes
 # route to display orders
@@ -86,7 +85,6 @@ def add_order():
     product_quantity = request.form.get('product_quantity')
     order_date = request.form.get('order_date')
     shipping_date = request.form.get('shipping_date')
-    delivery_date = request.form['delivery_date']
     
     # Create a session to interact with the database
     session = Session()
@@ -101,7 +99,6 @@ def add_order():
         product_quantity=product_quantity,
         order_date=order_date,
         shipping_date=shipping_date
-        delivery_date=delivery_date
     )
 
     # Add the new order to the session and commit to the database

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,27 @@
+# Starter pipeline
+# Start with a minimal pipeline that you can customize to build and deploy your code.
+# Add steps that build, run tests, deploy, and more:
+# https://aka.ms/yaml
+
+trigger:
+- secrets-feature
+
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+- task: Docker@2
+  inputs:
+    containerRegistry: 'Docker Hub'
+    repository: 'mayaaiuga/flask-app-sercrets'
+    command: 'buildAndPush'
+    Dockerfile: '**/Dockerfile'
+    tags: 'latest'
+- task: KubernetesManifest@1
+  inputs:
+    action: 'deploy'
+    connectionType: 'azureResourceManager'
+    azureSubscriptionConnection: 'aks-service-connection'
+    azureResourceGroup: 'aks-rg'
+    kubernetesCluster: 'aks-demo'
+    manifests: 'deployment.yaml'

--- a/templates/orders.html
+++ b/templates/orders.html
@@ -27,7 +27,6 @@
                         <th>Product Quantity</th>
                         <th>Order Date</th>
                         <th>Shipping Date</th>
-                        <th>Delivery Date</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -41,7 +40,6 @@
                             <td>{{ order.product_quantity }}</td>
                             <td>{{ order.order_date }}</td>
                             <td>{{ order.shipping_date }}</td>
-                            <td>{{ order.delivery_date}}</td>
                         </tr>
                     {% endfor %}
                 </tbody>
@@ -75,8 +73,6 @@
                 <input type="text" id="order_date" name="order_date" required><br>
                 <label for="shipping_date">Shipping Date:</label>
                 <input type="text" id="shipping_date" name="shipping_date" required><br>
-                <label for="delivery_date">Delivery Date:</label> <!-- Add this line -->
-                <input type="date" id="delivery_date" name="delivery_date"><br><br>  <!-- Add this line -->
                 <input type="submit" value="Add Order">
             </form>
         </div>


### PR DESCRIPTION
The delivery_date column in the backend database is deemed unnecessary. This pull request introduces a new branch, revert-delivery-date-3 (due to errors on versions 1 & 2), based on the main branch. Revert to the latest commit authored by the original repository's author, effectively rolling back the delivery_date changes.